### PR TITLE
update stencil core version to 0.17.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -18,7 +18,7 @@
   },
   "dependencies": {},
   "devDependencies": {
-    "@stencil/core": "~0.16.2"
+    "@stencil/core": "~0.17.0"
   },
   "license": "MIT"
 }


### PR DESCRIPTION
Any reason why we are not on 0.17 yet?